### PR TITLE
build: fix filename to correspond to feature name

### DIFF
--- a/webmention.el
+++ b/webmention.el
@@ -1,4 +1,4 @@
-;;; webmentions.el -- Webmention sending from Emacs
+;;; webmention.el -- Webmention sending from Emacs
 
 ;; Copyright (C) 2022 William Kearney
 ;; Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
Fixes an error when including this from load-path:

    ..../webmentions.elc failed to provide feature ‘webmentions’